### PR TITLE
Fix PSR-4 namespace for API controllers

### DIFF
--- a/reimbursement-be/app/Config/Routes.php
+++ b/reimbursement-be/app/Config/Routes.php
@@ -7,29 +7,29 @@ use CodeIgniter\Router\RouteCollection;
  */
 $routes->get('/', 'Home::index');
 
-$routes->post('api/login', 'App\Controllers\API\AuthController::login');
+$routes->post('api/login', 'App\Controllers\Api\AuthController::login');
 
 // Grup untuk semua API yang memerlukan autentikasi
 $routes->group('api', ['filter' => 'jwt'], static function ($routes) {
     // Rute untuk Reimbursement
-    $routes->get('reimbursements', 'App\Controllers\API\ReimbursementController::index'); // Melihat daftar
-    $routes->get('reimbursements/(:num)', 'App\Controllers\API\ReimbursementController::show/$1'); // Melihat detail
-    $routes->post('reimbursements', 'App\Controllers\API\ReimbursementController::create'); // Membuat pengajuan baru
+    $routes->get('reimbursements', 'App\Controllers\Api\ReimbursementController::index'); // Melihat daftar
+    $routes->get('reimbursements/(:num)', 'App\Controllers\Api\ReimbursementController::show/$1'); // Melihat detail
+    $routes->post('reimbursements', 'App\Controllers\Api\ReimbursementController::create'); // Membuat pengajuan baru
 
     // Rute untuk Proses Approval
-    $routes->post('reimbursements/(:num)/approve', 'App\Controllers\API\ReimbursementController::approve/$1'); // Menyetujui/menolak
+    $routes->post('reimbursements/(:num)/approve', 'App\Controllers\Api\ReimbursementController::approve/$1'); // Menyetujui/menolak
 });
 
 
 // Rute API tidak dilindungi
-$routes->post('api/login', 'App\Controllers\API\AuthController::login');
+$routes->post('api/login', 'App\Controllers\Api\AuthController::login');
 
 // Grup API dilindungi oleh JWT Filter
 $routes->group('api', ['filter' => 'jwt'], static function ($routes) {
     // Rute untuk Reimbursement
-    $routes->get('reimbursements', 'App\Controllers\API\ReimbursementController::index');
-    $routes->post('reimbursements', 'App\Controllers\API\ReimbursementController::create');
+    $routes->get('reimbursements', 'App\Controllers\Api\ReimbursementController::index');
+    $routes->post('reimbursements', 'App\Controllers\Api\ReimbursementController::create');
 
     // Rute untuk Approval
-    $routes->post('reimbursements/(:num)/approve', 'App\Controllers\API\ReimbursementController::approve/$1');
+    $routes->post('reimbursements/(:num)/approve', 'App\Controllers\Api\ReimbursementController::approve/$1');
 });

--- a/reimbursement-be/app/Controllers/Api/AuthController.php
+++ b/reimbursement-be/app/Controllers/Api/AuthController.php
@@ -1,4 +1,4 @@
-<?php namespace App\Controllers\API;
+<?php namespace App\Controllers\Api;
 
 use App\Models\UserModel;
 use CodeIgniter\RESTful\ResourceController;

--- a/reimbursement-be/app/Controllers/Api/ReimbursementController.php
+++ b/reimbursement-be/app/Controllers/Api/ReimbursementController.php
@@ -1,4 +1,4 @@
-<?php namespace App\Controllers\API;
+<?php namespace App\Controllers\Api;
 
 use App\Models\ReimbursementModel;
 use App\Models\ReimbursementDetailModel;


### PR DESCRIPTION
## Summary
- align API controller namespaces and routes with directory casing to satisfy PSR-4

## Testing
- `cd reimbursement-be && ./vendor/bin/phpunit --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_689713edd4e083289b72482c46dc3c51