### PR TITLE
Enable CORS for local development

### DIFF
--- a/reimbursement-be/app/Config/Cors.php
+++ b/reimbursement-be/app/Config/Cors.php
@@ -34,7 +34,7 @@ class Cors extends BaseConfig
          *   - ['http://localhost:8080']
          *   - ['https://www.example.com']
          */
-        'allowedOrigins' => [],
+        'allowedOrigins' => ['http://localhost:5173'],
 
         /**
          * Origin regex patterns for the `Access-Control-Allow-Origin` header.
@@ -68,7 +68,7 @@ class Cors extends BaseConfig
          *
          * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
          */
-        'allowedHeaders' => [],
+        'allowedHeaders' => ['Content-Type', 'Authorization'],
 
         /**
          * Set headers to expose.
@@ -93,7 +93,7 @@ class Cors extends BaseConfig
          *
          * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods
          */
-        'allowedMethods' => [],
+        'allowedMethods' => ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
 
         /**
          * Set how many seconds the results of a preflight request can be cached.

--- a/reimbursement-be/app/Config/Filters.php
+++ b/reimbursement-be/app/Config/Filters.php
@@ -73,6 +73,7 @@ class Filters extends BaseFilters
      */
     public array $globals = [
         'before' => [
+            'cors',
             // 'honeypot',
             // 'csrf',
             // 'invalidchars',

--- a/reimbursement-be/app/Config/Routes.php
+++ b/reimbursement-be/app/Config/Routes.php
@@ -6,6 +6,7 @@ use CodeIgniter\Router\RouteCollection;
  * @var RouteCollection $routes
  */
 $routes->get('/', 'Home::index');
+$routes->options('(:any)', static fn() => '');
 
 $routes->post('api/login', 'App\Controllers\API\AuthController::login');
 


### PR DESCRIPTION
## Summary
- Configure Cors.php to allow localhost frontend and common HTTP verbs/headers
- Apply CORS filter globally and handle preflight OPTIONS via catch-all route

## Testing
- `composer test`
- `curl -i -X OPTIONS -H "Origin: http://localhost:5173" -H "Access-Control-Request-Method: POST" http://localhost:8080/api/login`


------
https://chatgpt.com/codex/tasks/task_e_689714ded11483288a2a240483bd2750