### PR TITLE
Simplify reimbursement final status to completed

### DIFF
--- a/reimbursement-be/README.md
+++ b/reimbursement-be/README.md
@@ -66,3 +66,15 @@ Additionally, make sure that the following extensions are enabled in your PHP:
 - json (enabled by default - don't turn it off)
 - [mysqlnd](http://php.net/manual/en/mysqlnd.install.php) if you plan to use MySQL
 - [libcurl](http://php.net/manual/en/curl.requirements.php) if you plan to use the HTTP\CURLRequest library
+
+## Reimbursement Status Flow
+
+Reimbursements progress through these statuses:
+
+- `pending`
+- `approved_superior`
+- `approved_spv`
+- `approved_manager`
+- `completed` (after director approval)
+- `rejected`
+

--- a/reimbursement-be/app/Controllers/Api/ReimbursementController.php
+++ b/reimbursement-be/app/Controllers/Api/ReimbursementController.php
@@ -92,7 +92,7 @@ class ReimbursementController extends ResourceController
             case 'direct_superior': if ($currentStatus === 'pending') $newStatus = 'approved_superior'; break;
             case 'finance_spv': if ($currentStatus === 'approved_superior') $newStatus = 'approved_spv'; break;
             case 'finance_manager': if ($currentStatus === 'approved_spv') $newStatus = 'approved_manager'; break;
-            case 'director': if ($currentStatus === 'approved_manager') $newStatus = 'completed'; break; // Langsung completed
+            case 'director': if ($currentStatus === 'approved_manager') $newStatus = 'completed'; break; // Director approval completes the reimbursement
             default: return $this->failForbidden('Anda tidak memiliki hak akses untuk approval ini');
         }
 

--- a/reimbursement-be/app/Database/Migrations/2025-08-08-150343_CreateReimbursementsTable.php
+++ b/reimbursement-be/app/Database/Migrations/2025-08-08-150343_CreateReimbursementsTable.php
@@ -42,7 +42,7 @@ class CreateReimbursementsTable extends Migration
             ],
             'status' => [
                 'type'       => 'ENUM',
-                'constraint' => ['pending', 'approved_superior', 'approved_spv', 'approved_manager', 'approved_director', 'rejected', 'completed'],
+                'constraint' => ['pending', 'approved_superior', 'approved_spv', 'approved_manager', 'rejected', 'completed'],
                 'default'    => 'pending',
             ],
             'created_at' => [


### PR DESCRIPTION
## Summary
- drop unused `approved_director` status from reimbursements migration
- clarify controller comments to note director approval completes reimbursement
- document reimbursement status flow with `completed` as final stage

## Testing
- `CI_ENVIRONMENT=testing php spark migrate:refresh` *(fails: Undefined constant "CodeIgniter\Config\SUPPORTPATH")*
- `cd reimbursement-be && vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689718b941e083289e24c6f8f8595cc1