### PR TITLE
Remove duplicate API routes

### DIFF
--- a/reimbursement-be/app/Config/Routes.php
+++ b/reimbursement-be/app/Config/Routes.php
@@ -19,17 +19,3 @@ $routes->group('api', ['filter' => 'jwt'], static function ($routes) {
     // Rute untuk Proses Approval
     $routes->post('reimbursements/(:num)/approve', 'App\Controllers\API\ReimbursementController::approve/$1'); // Menyetujui/menolak
 });
-
-
-// Rute API tidak dilindungi
-$routes->post('api/login', 'App\Controllers\API\AuthController::login');
-
-// Grup API dilindungi oleh JWT Filter
-$routes->group('api', ['filter' => 'jwt'], static function ($routes) {
-    // Rute untuk Reimbursement
-    $routes->get('reimbursements', 'App\Controllers\API\ReimbursementController::index');
-    $routes->post('reimbursements', 'App\Controllers\API\ReimbursementController::create');
-
-    // Rute untuk Approval
-    $routes->post('reimbursements/(:num)/approve', 'App\Controllers\API\ReimbursementController::approve/$1');
-});


### PR DESCRIPTION
## Summary
- remove duplicated api/login and JWT-protected reimbursement routes from backend Routes config

## Testing
- `vendor/bin/phpunit --no-coverage`
- `php spark routes`


------
https://chatgpt.com/codex/tasks/task_e_689718b9a4f883289e82bfa6de2bb19e