### PR TITLE
test: cover session removal

### DIFF
--- a/reimbursement-be/tests/session/ExampleSessionTest.php
+++ b/reimbursement-be/tests/session/ExampleSessionTest.php
@@ -13,5 +13,11 @@ final class ExampleSessionTest extends CIUnitTestCase
 
         $session->set('logged_in', 123);
         $this->assertSame(123, $session->get('logged_in'));
+
+        $session->remove('logged_in');
+        $this->assertNull($session->get('logged_in'));
+
+        $session->destroy();
+        $this->assertFalse($session->has('logged_in'));
     }
 }


### PR DESCRIPTION
## Summary
- add tests ensuring session values can be removed and destroyed

## Testing
- `vendor/bin/phpunit --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_689718baec68832894d5953cabd12a27